### PR TITLE
Check for offshore countries

### DIFF
--- a/src/popolo/contenttypes/views/organization_view.py
+++ b/src/popolo/contenttypes/views/organization_view.py
@@ -188,9 +188,11 @@ class OrganizationView(DefaultView, BrowserView):
 
         vocabulary = factory(self)
         term = vocabulary.getTerm(value)
+        
+        # Declare common offshore havens  
+        offshore = ['VG', 'KY', 'PA', 'BS']
 
-        for offshore in ['VG', 'KY', 'PA', 'BS']:
-            if term.value in offshore:
-                return True
-            else:
-                return False
+        if any(term.value in country for country in offshore):
+            return True
+        else:
+            return False


### PR DESCRIPTION
This fixes the logic error that prevents setting the offshore ' (Offshore Tax Haven) ' warning on organization pages.

Fixes: https://github.com/OpenDevelopmentMekong/InvestmentMappingProject/issues/41