### PR TITLE
Backport Value error patch (Fixes #14)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,8 @@ setup(
         'plone.restapi',
         'plone.app.dexterity',
         'collective.dexteritytextindexer',
+        'collective.monkeypatcher',
+        'six',
     ],
     extras_require={
         'test': [

--- a/src/popolo/contenttypes/configure.zcml
+++ b/src/popolo/contenttypes/configure.zcml
@@ -3,6 +3,7 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
     xmlns:i18n="http://namespaces.zope.org/i18n"
     xmlns:plone="http://namespaces.plone.org/plone"
+    xmlns:monkey="http://namespaces.plone.org/monkey"
     i18n_domain="popolo.contenttypes">
 
   <i18n:registerTranslations directory="locales" />
@@ -50,6 +51,30 @@
 
   <include package=".views" />
   <include package=".vocabularies" />
+
+  <!-- -*- Local patches -*- -->
+  
+  <include package="collective.monkeypatcher" />
+
+  <!-- 
+  Patch for value errors in z3cform ajaxSelect widgets #14
+  https://github.com/Sinar/popolo.contenttypes/issues/14  
+  
+  -->
+
+  <monkey:patch
+      description="Fix z3c.form value error expection in ajaxSelect Widget"
+      class="plone.app.z3cform.converters.AjaxSelectWidgetConverter"
+      original="toWidgetValue"
+      replacement=".converters.toWidgetValue"
+      />
+
+  <monkey:patch
+      description="Fix z3c.form value error expection in ajaxSelect Widget"
+      class="plone.app.z3cform.converters.AjaxSelectWidgetConverter"
+      original="toFieldValue"
+      replacement=".converters.toFieldValue"
+      />
 
 
 </configure>

--- a/src/popolo/contenttypes/converters.py
+++ b/src/popolo/contenttypes/converters.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+
+from plone.app.z3cform import converters
+import six
+
+"""
+Patch for searching and adding resources #14
+https://github.com/Sinar/popolo.contenttypes/issues/14  
+
+Back porting plone.app.z3cform commit
+https://github.com/plone/plone.app.z3cform/commit/cb890dbbe64dc92acd2c68d5315f22c32ac4513f
+
+We overload the 'toWidgetValue' and toFieldValue from plone.app.z3cform 3.2.x version.  
+"""
+
+def toWidgetValue(self, value):
+    """Converts from field value to widget tokenized widget value.
+    :param value: Field value.
+    :type value: list |tuple | set
+    :returns: Items separated using separator defined on widget
+    :rtype: string
+    """
+    if not value:
+        return self.field.missing_value
+    vocabulary = self.widget.get_vocabulary()
+    tokenized_value = []
+    for term_value in value:
+        if vocabulary is not None:
+            try:
+                term = vocabulary.getTerm(term_value)
+                tokenized_value.append(term.token)
+                continue
+            except (LookupError, ValueError):
+                pass
+        tokenized_value.append(six.text_type(term_value))
+    return getattr(self.widget, 'separator', ';').join(tokenized_value)
+
+
+
+def toFieldValue(self, value):
+    """Converts from widget value to field.
+    :param value: Value inserted by AjaxSelect widget.
+    :type value: string
+    :returns: List of items
+    :rtype: list | tuple | set
+    """
+    collectionType = self.field._type
+    if isinstance(collectionType, tuple):
+        collectionType = collectionType[-1]
+    if not len(value):
+        return self.field.missing_value
+    valueType = self.field.value_type._type
+    if isinstance(valueType, tuple):
+        valueType = valueType[0]
+    separator = getattr(self.widget, 'separator', ';')
+    self.widget.update()  # needed to have a vocabulary
+    vocabulary = self.widget.get_vocabulary()
+    untokenized_value = []
+    for token in value.split(separator):
+        if vocabulary is not None:
+            try:
+                term = vocabulary.getTermByToken(token)
+                if valueType:
+                    untokenized_value.append(valueType(term.value))
+                else:
+                    untokenized_value.append(term.value)
+                continue
+            except (LookupError, ValueError):
+                pass
+        untokenized_value.append(
+            valueType(token) if valueType else token,
+        )
+    return collectionType(untokenized_value)


### PR DESCRIPTION
We use collective.monkeypatcher to backport  plone.app.z3cform commit https://github.com/plone/plone.app.z3cform/commit/cb890dbbe64dc92acd2c68d5315f22c32ac4513f

This minimal patch replaces the 'toWidgetValue' and toFieldValue from plone.app.z3cform 3.2.x version to fix #14 

The only significant change is that we 'six' and 'collective.monkeypatcher' are added dependencies.